### PR TITLE
Implement triggering, gathering, and copying

### DIFF
--- a/config/subjectsAndPaths.js
+++ b/config/subjectsAndPaths.js
@@ -1,10 +1,29 @@
 export const subjects = [
   {
     type: 'http://rdf.myexperiment.org/ontologies/base/Submission',
+    trigger: `
+      ?subject a <http://rdf.myexperiment.org/ontologies/base/Submission> .
+    `,
     path: `
       ?subject
         pav:createdBy ?organisation ;
         pav:providedBy ?vendor .
     `,
+    remove: {
+      delete: `
+        ?subject ?p ?o .
+      `,
+      where: `
+        ?subject ?p ?o .
+      `,
+    },
+    copy: {
+      insert: `
+        ?subject ?p ?o .
+      `,
+      where: `
+        ?subject ?p ?o .
+      `,
+    },
   },
 ];

--- a/deltaProcessing.js
+++ b/deltaProcessing.js
@@ -194,7 +194,9 @@ async function copyDataToVendorGraph(subject, config, graph) {
       }
     }
     WHERE {
-      BIND (${rst.termToString(subject)} AS ?subject)
-      ${config.copy.where}
+      GRAPH ?g {
+        BIND (${rst.termToString(subject)} AS ?subject)
+        ${config.copy.where}
+      }
     }`);
 }

--- a/deltaProcessing.js
+++ b/deltaProcessing.js
@@ -6,6 +6,10 @@ import * as N3 from 'n3';
 import * as conf from './config/subjectsAndPaths';
 const { namedNode } = N3.DataFactory;
 const sparqlJsonParser = new sjp.SparqlJsonParser();
+const connectionOptions = {
+  sparqlEndpoint: 'http://virtuoso:8890/sparql',
+  mayRetry: true,
+};
 
 /*
  * Takes delta messages, filters subjects, fetches already known data for those
@@ -189,6 +193,8 @@ async function removeDataFromVendorGraph(subject, config, graph) {
       BIND (${rst.termToString(subject)} AS ?subject)
       ${config.remove.where}
     }`,
+    undefined,
+    connectionOptions,
   );
 }
 
@@ -204,5 +210,7 @@ async function copyDataToVendorGraph(subject, config, graph) {
       BIND (${rst.termToString(subject)} AS ?subject)
       ${config.copy.where}
     }`,
+    undefined,
+    connectionOptions,
   );
 }

--- a/deltaProcessing.js
+++ b/deltaProcessing.js
@@ -30,7 +30,6 @@ export async function processDelta(changesets) {
 
   // Query all those subjects to see which are intersting according to a
   // configuration.
-  //Warning: Order matters for the next call, see comment below!
   const wantedSubjects = await getAllWantedSubjects(allSubjects);
 
   if (wantedSubjects.length < 1)
@@ -39,7 +38,6 @@ export async function processDelta(changesets) {
       reason: 'No subjects of interest in these changesets.',
     };
 
-    //Warning: Order matters for the next call, see comment below!
   for (const { subject, type, config } of wantedSubjects) {
     const vendorInfos = await getVendorInfoFromSubject(subject, type, config);
 
@@ -70,7 +68,6 @@ export async function processDelta(changesets) {
  * that are in the regular delta message format from the delta-notifier.
  * @returns {Array(NamedNode)} An array with RDF terms for unique subjects.
  */
-// Returns RDF terms per subject
 function getAllUniqueSubjects(changesets) {
   const allSubjects = changesets
     .map((changeset) => {


### PR DESCRIPTION
This PR attempts to provide a more configurable and flexible vendor-data-distribution-service (VDDS). Look at the provided configuration file to get an example of how this would work. By providing space for just raw (parts of) SPARQL queries, you get the possibilities of SPARQL to manipulate the data to your liking and even enrich the data.