### PR TITLE
Increase body size on delta messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,6 +35,7 @@ app.use(
     type: function (req) {
       return /^application\/json/.test(req.get('Content-Type'));
     },
+    limit: '50MB',
   }),
 );
 


### PR DESCRIPTION
Very simply put: increase the body size on delta messages (to 50MiB).

This is according to the `mu-javascript-template` [specification](https://github.com/mu-semtech/mu-javascript-template/tree/master?tab=readme-ov-file#handle-deltas-from-the-delta-service).