### PR TITLE
Implement healing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ following snippet in the `docker-compose.yml` as a service:
 
 ```yaml
 vendor-data-distribution:
-  image: lblod/vendor-data-distribution-service:1.0.0
+  image: lblod/vendor-data-distribution-service:x.y.z
 ```
 
 Because this service reacts to delta-messages, configure the `delta-notifier`

--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ service. Supply a value for them using the `environment` keyword in the
   perform the copying of data to the vendor graph. As these queries can become
   costly, you could configure them to run on Virtuoso directly. Not to be
   confused with `MU_SPARQL_ENDPOINT`.
+* `SPARQL_ENDPOINT_HEALING_OPERATIONS`: <em>(optional, default:
+  "http://virtuoso:8890/sparql")</em> the SPARQL endpoint for the queries that
+  perform the healing. <strong>Note: this defaults to Virtuoso directly! These
+  operations are not supposed to cause delta-notifier messages and are supposed
+  to run as fast as possible.</strong>
 * `MU_SPARQL_ENDPOINT`: <em>(optional, default:
   "http://database:8890/sparql")</em> the regular endpoint for SPARQL queries.
 * `LOGLEVEL`: <em>(optional, default: "silent", possible values: ["error",
@@ -178,6 +183,27 @@ service. Supply a value for them using the `environment` keyword in the
   "http://lblod.data.gift/errors")</em> graph in which to write errors to.
 * `ERROR_BASE`: <em>(optional, URI, default:
   "http://data.lblod.info/errors/")</em> base for the URI of created errors.
+
+## Healing
+
+<strong>This healing implementation is somewhat crude. Keep an eye on the logs
+to track its progress.</strong>
+
+Healing will cause this service to query the triplestore for all elegible
+subjects and copy their data to the vendor graph. From the existing config, the
+`type`, `trigger` and `path` properties are used to find elegible subjects. Old
+data is cleaned up with the `remove` property and new data is copied to the
+vendor graph(s) with the `insert` property. Healing will thus do the exact same
+thing as what otherwise would happen on a delta-message, but now the
+triplestore is queried for elegible subjects instead.
+
+To execute healing perform the following HTTP request:
+
+### POST `/healing`
+
+**Returns** `200` immediately, after which the healing will start.
+
+Inspect the logs for progress.
 
 ## Testing
 

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ import { v4 as uuid } from 'uuid';
 import { NAMESPACES as ns } from './env';
 import { BASES as b } from './env';
 import * as del from './deltaProcessing';
+import * as hea from './healing';
 import * as test from './test/test';
 import * as env from './env';
 import * as pbu from './parse-bindings-utils';
@@ -48,6 +49,26 @@ app.post('/delta', async function (req, res, next) {
     const changesets = req.body;
     const result = await del.processDelta(changesets);
     handleProcessingResult(result);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/*
+ * This endpoint is used for healing. This will query the database for ALL
+ * subjects in the triplestore to see if that data should be inserted in the
+ * vendor graph. This effectively replaces the need for migrations and
+ * provides a way to add data to the vendor graph in case of configuration
+ * changes, or if something went wrong in the application.
+ */
+app.post('/healing', async function (req, res, next) {
+  // Send success code back. We will execute the healing later.
+  res.status(200).send({
+    message:
+      'Healing will start immediately. Check the logs of this service to track progress.',
+  });
+  try {
+    await hea.heal();
   } catch (err) {
     next(err);
   }

--- a/deltaProcessing.js
+++ b/deltaProcessing.js
@@ -1,15 +1,5 @@
 import * as rst from 'rdf-string-ttl';
-import * as sjp from 'sparqljson-parse';
-import * as mas from '@lblod/mu-auth-sudo';
-import * as env from './env';
-import * as N3 from 'n3';
-import * as conf from './config/subjectsAndPaths';
-const { namedNode } = N3.DataFactory;
-const sparqlJsonParser = new sjp.SparqlJsonParser();
-const connectionOptions = {
-  sparqlEndpoint: env.SPARQL_ENDPOINT_COPY_OPERATIONS,
-  mayRetry: true,
-};
+import * as hel from './helpers';
 
 /*
  * Takes delta messages, filters subjects, fetches already known data for those
@@ -30,11 +20,11 @@ export async function processDelta(changesets) {
   let wasIngestSuccesful = false; // Keep track of the state to return to caller.
 
   // Filter all subjects (just all subjects, filter later which ones needed)
-  const allSubjects = getAllUniqueSubjects(changesets);
+  const allSubjects = hel.getAllUniqueSubjects(changesets);
 
   // Query all those subjects to see which are intersting according to a
   // configuration.
-  const wantedSubjects = await getAllWantedSubjects(allSubjects);
+  const wantedSubjects = await hel.getAllWantedSubjects(allSubjects);
 
   if (wantedSubjects.length < 1)
     return {
@@ -43,7 +33,11 @@ export async function processDelta(changesets) {
     };
 
   for (const { subject, type, config } of wantedSubjects) {
-    const vendorInfos = await getVendorInfoFromSubject(subject, type, config);
+    const vendorInfos = await hel.getVendorInfoFromSubject(
+      subject,
+      type,
+      config,
+    );
 
     if (!vendorInfos.length) {
       console.log(
@@ -56,161 +50,14 @@ export async function processDelta(changesets) {
 
     for (const vendorInfo of vendorInfos) {
       const vendorGraph = `http://mu.semte.ch/graphs/vendors/${vendorInfo.vendor.id.value}/${vendorInfo.organisation.id.value}`;
-      await removeDataFromVendorGraph(subject, config, vendorGraph);
+      await hel.removeDataFromVendorGraph(subject, config, vendorGraph);
     }
     for (const vendorInfo of vendorInfos) {
       const vendorGraph = `http://mu.semte.ch/graphs/vendors/${vendorInfo.vendor.id.value}/${vendorInfo.organisation.id.value}`;
-      await copyDataToVendorGraph(subject, config, vendorGraph);
+      await hel.copyDataToVendorGraph(subject, config, vendorGraph);
     }
 
     wasIngestSuccesful = true;
   }
   return { success: wasIngestSuccesful };
-}
-
-/*
- * Gather distinct subjects from all the changes in the changesets.
- *
- * @function
- * @param {Array(Object)} changesets - This array contains JavaScript objects
- * that are in the regular delta message format from the delta-notifier.
- * @returns {Array(NamedNode)} An array with RDF terms for unique subjects.
- */
-function getAllUniqueSubjects(changesets) {
-  const allSubjects = changesets
-    .map((changeset) => {
-      return changeset.inserts.concat(changeset.deletes);
-    })
-    .flat()
-    .map((triple) => {
-      return triple.subject.value;
-    });
-  const subjectStrings = [...new Set(allSubjects)];
-  return subjectStrings.map(namedNode);
-}
-
-/*
- * Fetch types (rdf:type) for the subjects and filter them by the
- * configuration.
- *
- * @async
- * @function
- * @param {Array(NamedNode)} subjects - An array with subjects.
- * @returns {Array(NamedNode)} Same as input parameter, but filtered.
- *
- * WARNING:
- *  - The current implementation works for deletes too, but that's
- *    mainly because the vendor-graph is not flushed when this function is
- *    called. So: be cautious when shuffling this function around
- */
-async function getAllWantedSubjects(subjects) {
-  const response = await mas.querySudo(`
-    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-
-    SELECT DISTINCT ?subject ?type WHERE {
-      VALUES ?subject {
-        ${subjects.map(rst.termToString).join(' ')}
-      }
-      ?subject rdf:type ?type .
-    }
-  `);
-  const parsedResults = sparqlJsonParser.parseJsonResults(response);
-  const wantedSubjects = [];
-
-  for (const result of parsedResults) {
-    const confs = conf.subjects.filter((s) => s.type === result.type.value);
-    for (const conf of confs) {
-      const triggerResponse = await mas.querySudo(`
-        ASK {
-          BIND (${rst.termToString(result.subject)} AS ?subject)
-          ${conf.trigger}
-        }`);
-      const isTriggering = sparqlJsonParser.parseJsonBoolean(triggerResponse);
-      if (isTriggering)
-        wantedSubjects.push({
-          subject: result.subject,
-          type: result.type,
-          config: conf,
-        });
-    }
-  }
-  return wantedSubjects;
-}
-
-/*
- * Get an object with information about the vendor that published a set of
- * data. Starting from the subject and its type (rdf:type).
- *
- * @async
- * @function
- * @param {NamedNode} subject - Represents the URI of the subject that is being
- * reported by the vendor we want the information about.
- * @param {NamedNode} type - Represents the URI of the type of the subject.
- * @returns {Object} An object with keys `vendor` and `organisation`, each
- * containing a new object with keys `id` and `uri` containing the mu:uuid and
- * the URI respectively. Returns undefined when no config for this subject is
- * found.
- */
-async function getVendorInfoFromSubject(subject, type, config) {
-  if (config.path) {
-    const response = await mas.querySudo(`
-      ${env.SPARQL_PREFIXES}
-      SELECT DISTINCT ?vendor ?vendorId ?organisation ?organisationId WHERE {
-        BIND (${rst.termToString(subject)} AS ?subject)
-        ${config.path}
-        ?vendor
-          muAccount:canActOnBehalfOf ?organisation ;
-          mu:uuid ?vendorId .
-        ?organisation
-          mu:uuid ?organisationId .
-      }
-    `);
-    const parsedResults = sparqlJsonParser.parseJsonResults(response);
-    return parsedResults.map((r) => {
-      return {
-        vendor: {
-          id: r?.vendorId,
-          uri: r?.vendor,
-        },
-        organisation: {
-          id: r?.organisationId,
-          uri: r?.organisation,
-        },
-      };
-    });
-  }
-}
-
-async function removeDataFromVendorGraph(subject, config, graph) {
-  await mas.updateSudo(
-    `
-    DELETE {
-      GRAPH <${graph}> {
-        ${config.remove.delete}
-      }
-    }
-    WHERE {
-      BIND (${rst.termToString(subject)} AS ?subject)
-      ${config.remove.where}
-    }`,
-    undefined,
-    connectionOptions,
-  );
-}
-
-async function copyDataToVendorGraph(subject, config, graph) {
-  await mas.updateSudo(
-    `
-    INSERT {
-      GRAPH <${graph}> {
-        ${config.copy.insert}
-      }
-    }
-    WHERE {
-      BIND (${rst.termToString(subject)} AS ?subject)
-      ${config.copy.where}
-    }`,
-    undefined,
-    connectionOptions,
-  );
 }

--- a/env.js
+++ b/env.js
@@ -7,6 +7,11 @@ export const SPARQL_ENDPOINT_COPY_OPERATIONS = envvar
   .default('http://database:8890/sparql')
   .asUrlString();
 
+export const SPARQL_ENDPOINT_HEALING_OPERATIONS = envvar
+  .get('SPARQL_ENDPOINT_HEALING_OPERATIONS')
+  .default('http://database:8890/sparql')
+  .asUrlString();
+
 export const CREATOR =
   'http://lblod.data.gift/services/vendor-data-distribution-service';
 

--- a/env.js
+++ b/env.js
@@ -9,7 +9,7 @@ export const SPARQL_ENDPOINT_COPY_OPERATIONS = envvar
 
 export const SPARQL_ENDPOINT_HEALING_OPERATIONS = envvar
   .get('SPARQL_ENDPOINT_HEALING_OPERATIONS')
-  .default('http://database:8890/sparql')
+  .default('http://virtuoso:8890/sparql')
   .asUrlString();
 
 export const CREATOR =

--- a/healing.js
+++ b/healing.js
@@ -1,0 +1,60 @@
+import * as env from './env';
+import * as hel from './helpers';
+import * as mas from '@lblod/mu-auth-sudo';
+import * as conf from './config/subjectsAndPaths';
+import * as rst from 'rdf-string-ttl';
+import * as sjp from 'sparqljson-parse';
+const sparqlJsonParser = new sjp.SparqlJsonParser();
+import * as N3 from 'n3';
+const { namedNode } = N3.DataFactory;
+const connectionOptions = {
+  sparqlEndpoint: env.SPARQL_ENDPOINT_HEALING_OPERATIONS,
+  mayRetry: true,
+};
+
+export async function heal() {
+  for (const config of conf.subjects) {
+    const { type, trigger, path } = config;
+
+    // Construct one combined query, what otherwise happens on a delta
+    const response = await mas.querySudo(
+      `
+      ${env.SPARQL_PREFIXES}
+
+      SELECT DISTINCT ?subject ?vendor ?vendorId ?organisation ?organisationId
+      WHERE {
+        GRAPH ?g {
+          ?subject rdf:type ${rst.termToString(namedNode(type))} .
+          ${trigger}
+        }
+        FILTER (REGEX(STR(?g), "^http://mu.semte.ch/graphs/organizations/"))
+        ${path}
+        ?vendor
+          muAccount:canActOnBehalfOf ?organisation ;
+          mu:uuid ?vendorId .
+        ?organisation
+          mu:uuid ?organisationId .
+      }
+    `,
+      undefined,
+      connectionOptions,
+    );
+    const parsedResults = sparqlJsonParser.parseJsonResults(response);
+
+    // For each subject that is elegible for the vendor graph, move its data to it
+    for (let i = 0; i < parsedResults.length; i++) {
+      const entry = parsedResults[i];
+      const vendorGraph = `http://mu.semte.ch/graphs/vendors/${entry.vendorId.value}/${entry.organisationId.value}`;
+      await hel.removeDataFromVendorGraph(entry.subject, config, vendorGraph);
+      await hel.copyDataToVendorGraph(entry.subject, config, vendorGraph);
+
+      //Nice logging
+      const percentage = Math.round(((i + 1) * 100) / parsedResults.length);
+      console.log(
+        `Processed ${i + 1}/${
+          parsedResults.length
+        } (${percentage}%) of type ${type}`,
+      );
+    }
+  }
+}

--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,158 @@
+import * as rst from 'rdf-string-ttl';
+import * as sjp from 'sparqljson-parse';
+import * as mas from '@lblod/mu-auth-sudo';
+import * as env from './env';
+import * as N3 from 'n3';
+import * as conf from './config/subjectsAndPaths';
+const { namedNode } = N3.DataFactory;
+const sparqlJsonParser = new sjp.SparqlJsonParser();
+const connectionOptions = {
+  sparqlEndpoint: env.SPARQL_ENDPOINT_COPY_OPERATIONS,
+  mayRetry: true,
+};
+
+/*
+ * Gather distinct subjects from all the changes in the changesets.
+ *
+ * @function
+ * @param {Array(Object)} changesets - This array contains JavaScript objects
+ * that are in the regular delta message format from the delta-notifier.
+ * @returns {Array(NamedNode)} An array with RDF terms for unique subjects.
+ */
+export function getAllUniqueSubjects(changesets) {
+  const allSubjects = changesets
+    .map((changeset) => {
+      return changeset.inserts.concat(changeset.deletes);
+    })
+    .flat()
+    .map((triple) => {
+      return triple.subject.value;
+    });
+  const subjectStrings = [...new Set(allSubjects)];
+  return subjectStrings.map(namedNode);
+}
+
+/*
+ * Fetch types (rdf:type) for the subjects and filter them by the
+ * configuration.
+ *
+ * @async
+ * @function
+ * @param {Array(NamedNode)} subjects - An array with subjects.
+ * @returns {Array(NamedNode)} Same as input parameter, but filtered.
+ *
+ * WARNING:
+ *  - The current implementation works for deletes too, but that's
+ *    mainly because the vendor-graph is not flushed when this function is
+ *    called. So: be cautious when shuffling this function around
+ */
+export async function getAllWantedSubjects(subjects) {
+  const response = await mas.querySudo(`
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+    SELECT DISTINCT ?subject ?type WHERE {
+      VALUES ?subject {
+        ${subjects.map(rst.termToString).join(' ')}
+      }
+      ?subject rdf:type ?type .
+    }
+  `);
+  const parsedResults = sparqlJsonParser.parseJsonResults(response);
+  const wantedSubjects = [];
+
+  for (const result of parsedResults) {
+    const confs = conf.subjects.filter((s) => s.type === result.type.value);
+    for (const conf of confs) {
+      const triggerResponse = await mas.querySudo(`
+        ASK {
+          BIND (${rst.termToString(result.subject)} AS ?subject)
+          ${conf.trigger}
+        }`);
+      const isTriggering = sparqlJsonParser.parseJsonBoolean(triggerResponse);
+      if (isTriggering)
+        wantedSubjects.push({
+          subject: result.subject,
+          type: result.type,
+          config: conf,
+        });
+    }
+  }
+  return wantedSubjects;
+}
+/*
+ * Get an object with information about the vendor that published a set of
+ * data. Starting from the subject and its type (rdf:type).
+ *
+ * @async
+ * @function
+ * @param {NamedNode} subject - Represents the URI of the subject that is being
+ * reported by the vendor we want the information about.
+ * @param {NamedNode} type - Represents the URI of the type of the subject.
+ * @returns {Object} An object with keys `vendor` and `organisation`, each
+ * containing a new object with keys `id` and `uri` containing the mu:uuid and
+ * the URI respectively. Returns undefined when no config for this subject is
+ * found.
+ */
+export async function getVendorInfoFromSubject(subject, type, config) {
+  if (config.path) {
+    const response = await mas.querySudo(`
+      ${env.SPARQL_PREFIXES}
+      SELECT DISTINCT ?vendor ?vendorId ?organisation ?organisationId WHERE {
+        BIND (${rst.termToString(subject)} AS ?subject)
+        ${config.path}
+        ?vendor
+          muAccount:canActOnBehalfOf ?organisation ;
+          mu:uuid ?vendorId .
+        ?organisation
+          mu:uuid ?organisationId .
+      }
+    `);
+    const parsedResults = sparqlJsonParser.parseJsonResults(response);
+    return parsedResults.map((r) => {
+      return {
+        vendor: {
+          id: r?.vendorId,
+          uri: r?.vendor,
+        },
+        organisation: {
+          id: r?.organisationId,
+          uri: r?.organisation,
+        },
+      };
+    });
+  }
+}
+
+export async function removeDataFromVendorGraph(subject, config, graph) {
+  await mas.updateSudo(
+    `
+    DELETE {
+      GRAPH <${graph}> {
+        ${config.remove.delete}
+      }
+    }
+    WHERE {
+      BIND (${rst.termToString(subject)} AS ?subject)
+      ${config.remove.where}
+    }`,
+    undefined,
+    connectionOptions,
+  );
+}
+
+export async function copyDataToVendorGraph(subject, config, graph) {
+  await mas.updateSudo(
+    `
+    INSERT {
+      GRAPH <${graph}> {
+        ${config.copy.insert}
+      }
+    }
+    WHERE {
+      BIND (${rst.termToString(subject)} AS ?subject)
+      ${config.copy.where}
+    }`,
+    undefined,
+    connectionOptions,
+  );
+}

--- a/helpers.js
+++ b/helpers.js
@@ -65,7 +65,7 @@ export async function getAllWantedSubjects(subjects) {
     for (const conf of confs) {
       const triggerResponse = await mas.querySudo(`
         ASK {
-          BIND (${rst.termToString(result.subject)} AS ?subject)
+          VALUES ?subject { ${rst.termToString(result.subject)} }
           ${conf.trigger}
         }`);
       const isTriggering = sparqlJsonParser.parseJsonBoolean(triggerResponse);
@@ -98,7 +98,7 @@ export async function getVendorInfoFromSubject(subject, type, config) {
     const response = await mas.querySudo(`
       ${env.SPARQL_PREFIXES}
       SELECT DISTINCT ?vendor ?vendorId ?organisation ?organisationId WHERE {
-        BIND (${rst.termToString(subject)} AS ?subject)
+        VALUES ?subject { ${rst.termToString(subject)} }
         ${config.path}
         ?vendor
           muAccount:canActOnBehalfOf ?organisation ;
@@ -132,7 +132,7 @@ export async function removeDataFromVendorGraph(subject, config, graph) {
       }
     }
     WHERE {
-      BIND (${rst.termToString(subject)} AS ?subject)
+      VALUES ?subject { ${rst.termToString(subject)} }
       ${config.remove.where}
     }`,
     undefined,
@@ -149,7 +149,7 @@ export async function copyDataToVendorGraph(subject, config, graph) {
       }
     }
     WHERE {
-      BIND (${rst.termToString(subject)} AS ?subject)
+      VALUES ?subject { ${rst.termToString(subject)} }
       ${config.copy.where}
     }`,
     undefined,

--- a/helpers.js
+++ b/helpers.js
@@ -79,6 +79,7 @@ export async function getAllWantedSubjects(subjects) {
   }
   return wantedSubjects;
 }
+
 /*
  * Get an object with information about the vendor that published a set of
  * data. Starting from the subject and its type (rdf:type).


### PR DESCRIPTION
Without changing too much about this service, this implements some basic healing mechanism. Healing in this case means that this service will use the already existing config to query the triplestore for subjects that match the type and trigger, find the related organisation and vendor, remove stale data from the vendor graph and copies the needed data to the vendor graph. This is basically what happens on a delta message, but the service now queries the triplestore for the data instead.

Healing can replace all manual migrations. If the config changes, you could execute the healing to copy the new data. If a new vendor is added to the application, if the application or delta-notifier has somehow crashed and you fear that some vendor data is missing because of it, the healing could repair that. Can also be used when the VDDS is added to a completely new stack and historical data is required in the vendor graphs.