### PR TITLE
Allow to skip deteles and filter on type

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,26 @@ To execute healing perform the following HTTP request:
 
 ### POST `/healing`
 
+**Body** *OPTIONAL* JSON with the following structure:
+
+```json
+{
+  "skipDeletes": true,
+  "onlyTheseTypes": [ "http://rdf.myexperiment.org/ontologies/base/Submission" ]
+}
+```
+
+* `skipDeletes`: <em>(optional, default: `false`)</em> if set to `true`, the
+  deletes are not executed. This is usually used on an initial healing when
+  there is nothing to delete. Generally used when nothing has changed, but only
+  incrementally added (e.g. a new vendor, an new type to copy to the vendors,
+  ...).
+* `onlyTheseTypes`: <em>(optional, default: `[]`)</em> an array of IRI's in
+  string form that represent the type, as defined in the config, to copy to the
+  vendor. This can speed up the healing when only one type is needed (e.g. when
+  the config items overlap). When empty, all types are copied to the vendor
+  graph.
+
 **Returns** `200` immediately, after which the healing will start.
 
 Inspect the logs for progress.

--- a/app.js
+++ b/app.js
@@ -68,7 +68,15 @@ app.post('/healing', async function (req, res, next) {
       'Healing will start immediately. Check the logs of this service to track progress.',
   });
   try {
-    await hea.heal();
+    const skipDeletes = !!req.body?.skipDeletes || false;
+    const onlyTypes =
+      req.body?.onlyTheseTypes?.constructor?.name === 'Array'
+        ? req.body?.onlyTheseTypes
+        : [];
+    console.log(
+      `Will start healing with skipDeletes ${skipDeletes} and filter [${onlyTypes.join(', ')}]`,
+    );
+    await hea.heal(skipDeletes, onlyTypes);
   } catch (err) {
     next(err);
   }

--- a/deltaProcessing.js
+++ b/deltaProcessing.js
@@ -51,9 +51,6 @@ export async function processDelta(changesets) {
     for (const vendorInfo of vendorInfos) {
       const vendorGraph = `http://mu.semte.ch/graphs/vendors/${vendorInfo.vendor.id.value}/${vendorInfo.organisation.id.value}`;
       await hel.removeDataFromVendorGraph(subject, config, vendorGraph);
-    }
-    for (const vendorInfo of vendorInfos) {
-      const vendorGraph = `http://mu.semte.ch/graphs/vendors/${vendorInfo.vendor.id.value}/${vendorInfo.organisation.id.value}`;
       await hel.copyDataToVendorGraph(subject, config, vendorGraph);
     }
 

--- a/helpers.js
+++ b/helpers.js
@@ -125,6 +125,8 @@ export async function getVendorInfoFromSubject(subject, type, config) {
 }
 
 export async function removeDataFromVendorGraph(subject, config, graph) {
+  // No filter on graph in the where clause, we need to be able to delete
+  // everything
   await mas.updateSudo(
     `
     DELETE {
@@ -150,8 +152,11 @@ export async function copyDataToVendorGraph(subject, config, graph) {
       }
     }
     WHERE {
-      VALUES ?subject { ${rst.termToString(subject)} }
-      ${config.copy.where}
+      GRAPH ?g {
+        VALUES ?subject { ${rst.termToString(subject)} }
+        ${config.copy.where}
+      }
+      FILTER (REGEX(STR(?g), "^http://mu.semte.ch/graphs/organizations/"))
     }`,
     undefined,
     connectionOptions,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vendor-data-distribution-service",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vendor-data-distribution-service",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "@lblod/mu-auth-sudo": "^0.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vendor-data-distribution-service",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vendor-data-distribution-service",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "@lblod/mu-auth-sudo": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vendor-data-distribution-service",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Service to distribute data for the SPARQL endpoint to vendors in their own organisation graph.",
   "dependencies": {
     "@lblod/mu-auth-sudo": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vendor-data-distribution-service",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Service to distribute data for the SPARQL endpoint to vendors in their own organisation graph.",
   "dependencies": {
     "@lblod/mu-auth-sudo": "^0.6.0",


### PR DESCRIPTION
As a property in the JSON body, the `skipDeletes` allows you to not execute the delete queries. In case of an initial healing, there is nothing to delete, so this could drastically speed up the healing process. Also implement a filter on the types to heal. In some scenarios, the items in the config overlap a little or completely. You can now filter on the types you want to copy to the vendor graph to not execute redundant queries and speed up the healing.