### PR TITLE
Implement mu-scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,32 @@ the `rules.js` file for the `delta-notifier` service.
 }
 ```
 
+Because this service is going to create a lot of data, but in very specific
+graphs that are not accessible to `mu-cl-resources`, you should also add the
+`mu-call-scope-id` as an opt-out in the `delta-notifier` config for
+`mu-cl-resources`. Without this opt-out, the service might have to endure heavy
+loads of deltas that are not useful, wasting resources. To add this scope
+identifier, make sure the config for `mu-cl-resources` has the
+`optOutMuScopeIds` property like in the following example:
+
+```JavaScript
+{
+  match: {},
+  callback: {
+    url: "http://resource/.mu/delta",
+    method: "POST"
+  },
+  options: {
+    resourceFormat: "v0.0.1",
+    gracePeriod: 1000,
+    ignoreFromSelf: true,
+    optOutMuScopeIds: [
+      "http://redpencil.data.gift/id/concept/muScope/deltas/vendor-data",
+    ],
+  }
+},
+```
+
 For making sure the vendors can only read from their own graph, you can
 configure `mu-authorization` with the following specification:
 
@@ -195,6 +221,13 @@ service. Supply a value for them using the `environment` keyword in the
   to run as fast as possible.</strong>
 * `MU_SPARQL_ENDPOINT`: <em>(optional, default:
   "http://database:8890/sparql")</em> the regular endpoint for SPARQL queries.
+* `MU_SCOPE`: <em>(optional, default:
+  "http://redpencil.data.gift/id/concept/muScope/deltas/vendor-data")</em> this
+  is the `mu-call-scope-id` that can be used in the `delta-notifier` config as
+  an opt-out. See the `delta-notifier` setup above. If you bypass
+  `mu-authorization` using some of the above evironment variables, this scope
+  id has no effect. It only affects queries through `mu-authorization` and the
+  `delta-notifier`.
 * `LOGLEVEL`: <em>(optional, default: "silent", possible values: ["error",
   "info", "silent"])</em> level of logging to the console.
 * `WRITE_ERRORS`: <em>(optional, boolean as string, default: "false")</em> set

--- a/env.js
+++ b/env.js
@@ -37,6 +37,11 @@ export const ERROR_BASE = envvar
   .default('http://data.lblod.info/errors/')
   .asUrlString();
 
+export const MU_SCOPE = envvar
+  .get('MU_SCOPE')
+  .default('http://redpencil.data.gift/id/concept/muScope/deltas/vendor-data')
+  .asUrlString();
+
 const PREFIXES = {
   rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
   xsd: 'http://www.w3.org/2001/XMLSchema#',

--- a/helpers.js
+++ b/helpers.js
@@ -6,7 +6,10 @@ import * as N3 from 'n3';
 import * as conf from './config/subjectsAndPaths';
 const { namedNode } = N3.DataFactory;
 const sparqlJsonParser = new sjp.SparqlJsonParser();
-const connectionOptions = {
+const sparqlConnectionHeaders = {
+  'mu-call-scope-id': env.MU_SCOPE,
+};
+const sparqlConnectionOptions = {
   sparqlEndpoint: env.SPARQL_ENDPOINT_COPY_OPERATIONS,
   mayRetry: true,
 };
@@ -138,8 +141,8 @@ export async function removeDataFromVendorGraph(subject, config, graph) {
       VALUES ?subject { ${rst.termToString(subject)} }
       ${config.remove.where}
     }`,
-    undefined,
-    connectionOptions,
+    sparqlConnectionHeaders,
+    sparqlConnectionOptions,
   );
 }
 
@@ -158,8 +161,8 @@ export async function copyDataToVendorGraph(subject, config, graph) {
       }
       FILTER (REGEX(STR(?g), "^http://mu.semte.ch/graphs/organizations/"))
     }`,
-    undefined,
-    connectionOptions,
+    sparqlConnectionHeaders,
+    sparqlConnectionOptions,
   );
 }
 
@@ -197,7 +200,7 @@ export async function postProcess(subject, config, graph) {
       }
     }
     `,
-    undefined,
-    connectionOptions,
+    sparqlConnectionHeaders,
+    sparqlConnectionOptions,
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vendor-data-distribution-service",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vendor-data-distribution-service",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@lblod/mu-auth-sudo": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vendor-data-distribution-service",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Service to distribute data for the SPARQL endpoint to vendors in their own organisation graph.",
   "dependencies": {
     "@lblod/mu-auth-sudo": "^0.6.0",


### PR DESCRIPTION
Implements the use of `mu-call-scope-id` to the SPARQL update and delete requests so that services can be opt-out of delta-messages.

This is done by just adding a header to the relevant requests, so that the `delta-notifier` can decide, based on its config, to send or ignore these delta messages.