### PR TITLE
Fix the use of connection options for healing

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -127,7 +127,13 @@ export async function getVendorInfoFromSubject(subject, type, config) {
   }
 }
 
-export async function removeDataFromVendorGraph(subject, config, graph) {
+export async function removeDataFromVendorGraph(
+  subject,
+  config,
+  graph,
+  conHeaders = sparqlConnectionHeaders,
+  conOptions = sparqlConnectionOptions,
+) {
   // No filter on graph in the where clause, we need to be able to delete
   // everything
   await mas.updateSudo(
@@ -141,12 +147,18 @@ export async function removeDataFromVendorGraph(subject, config, graph) {
       VALUES ?subject { ${rst.termToString(subject)} }
       ${config.remove.where}
     }`,
-    sparqlConnectionHeaders,
-    sparqlConnectionOptions,
+    conHeaders,
+    conOptions,
   );
 }
 
-export async function copyDataToVendorGraph(subject, config, graph) {
+export async function copyDataToVendorGraph(
+  subject,
+  config,
+  graph,
+  conHeaders = sparqlConnectionHeaders,
+  conOptions = sparqlConnectionOptions,
+) {
   await mas.updateSudo(
     `
     INSERT {
@@ -161,12 +173,18 @@ export async function copyDataToVendorGraph(subject, config, graph) {
       }
       FILTER (REGEX(STR(?g), "^http://mu.semte.ch/graphs/organizations/"))
     }`,
-    sparqlConnectionHeaders,
-    sparqlConnectionOptions,
+    conHeaders,
+    conOptions,
   );
 }
 
-export async function postProcess(subject, config, graph) {
+export async function postProcess(
+  subject,
+  config,
+  graph,
+  conHeaders = sparqlConnectionHeaders,
+  conOptions = sparqlConnectionOptions,
+) {
   // No delete and insert → nothing to do
   if (!(config?.post?.delete || config?.post?.insert)) return;
   // No where → invalid post processing config
@@ -200,7 +218,7 @@ export async function postProcess(subject, config, graph) {
       }
     }
     `,
-    sparqlConnectionHeaders,
-    sparqlConnectionOptions,
+    conHeaders,
+    conOptions,
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vendor-data-distribution-service",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vendor-data-distribution-service",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "@lblod/mu-auth-sudo": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vendor-data-distribution-service",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Service to distribute data for the SPARQL endpoint to vendors in their own organisation graph.",
   "dependencies": {
     "@lblod/mu-auth-sudo": "^0.6.0",


### PR DESCRIPTION
It seems that healing did not respect the environment variables for the connection options. That is because the actual copying of data is done in another file with its own connection options for a different environment variable.