### PR TITLE
Looking for a way to avoid race conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ service. Supply a value for them using the `environment` keyword in the
 * `ERROR_BASE`: <em>(optional, URI, default:
   "http://data.lblod.info/errors/")</em> base for the URI of created errors.
 
+* `MIN_DELAY_TO_PROCESS_NEXT_DELTA`: (to avoid potential race conditions) Minimum delay in ms before processing next delta. Default is 1000 ms.
+* `MAX_DELAY_TO_PROCESS_NEXT_DELTA`: Maximum delay in ms before processing next delta. Default is 2000 ms.
+
 ## Healing
 
 <strong>This healing implementation is somewhat crude. Keep an eye on the logs

--- a/app.js
+++ b/app.js
@@ -46,6 +46,7 @@ app.post('/delta', async function (req, res, next) {
   res.status(200).end();
 
   try {
+    await randomDelay(env.MIN_DELAY_TO_PROCESS_NEXT_DELTA, env.MAX_DELAY_TO_PROCESS_NEXT_DELTA);
     const changesets = req.body;
     const result = await del.processDelta(changesets);
     handleProcessingResult(result);
@@ -210,4 +211,11 @@ function handleProcessingResult(result) {
   if (result.success) return;
   if (env.LOGLEVEL == 'error' || env.LOGLEVEL == 'info')
     console.log(result.reason);
+}
+
+async function randomDelay(min = 1000, max = 2000) {
+  return new Promise(resolve => {
+    const duration = Math.random() * (max - min) + min;
+    setTimeout(resolve, duration);
+  });
 }

--- a/app.js
+++ b/app.js
@@ -216,7 +216,7 @@ function handleProcessingResult(result) {
 async function randomDelay(min = 1000, max = 2000) {
   return new Promise(resolve => {
     const duration = Math.random() * (max - min) + min;
-    console.log(`Waiting ${duration}...`);
+    console.log(`Waiting ${duration} ms...`);
     setTimeout(resolve, duration);
   });
 }

--- a/app.js
+++ b/app.js
@@ -216,6 +216,7 @@ function handleProcessingResult(result) {
 async function randomDelay(min = 1000, max = 2000) {
   return new Promise(resolve => {
     const duration = Math.random() * (max - min) + min;
+    console.log(`Waiting ${duration}...`);
     setTimeout(resolve, duration);
   });
 }

--- a/app.js
+++ b/app.js
@@ -41,12 +41,12 @@ app.use(
 );
 
 app.post('/delta', async function (req, res, next) {
+  await randomDelay(env.MIN_DELAY_TO_PROCESS_NEXT_DELTA, env.MAX_DELAY_TO_PROCESS_NEXT_DELTA);
   // We can already send a 200 back. The delta-notifier does not care about the
   // result, as long as the request is closed.
   res.status(200).end();
 
   try {
-    await randomDelay(env.MIN_DELAY_TO_PROCESS_NEXT_DELTA, env.MAX_DELAY_TO_PROCESS_NEXT_DELTA);
     const changesets = req.body;
     const result = await del.processDelta(changesets);
     handleProcessingResult(result);

--- a/env.js
+++ b/env.js
@@ -37,6 +37,16 @@ export const ERROR_BASE = envvar
   .default('http://data.lblod.info/errors/')
   .asUrlString();
 
+export const MIN_DELAY_TO_PROCESS_NEXT_DELTA = envvar
+  .get('MIN_DELAY_TO_PROCESS_NEXT_DELTA')
+  .default('1000')
+  .asIntPositive();
+
+export const MAX_DELAY_TO_PROCESS_NEXT_DELTA = envvar
+  .get('MAX_DELAY_TO_PROCESS_NEXT_DELTA')
+  .default('2000')
+  .asIntPositive();
+
 export const MU_SCOPE = envvar
   .get('MU_SCOPE')
   .default('http://redpencil.data.gift/id/concept/muScope/deltas/vendor-data')

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.6.1",
   "description": "Service to distribute data for the SPARQL endpoint to vendors in their own organisation graph.",
   "dependencies": {
+    "async-await-mutex-lock": "^1.0.9",
     "@lblod/mu-auth-sudo": "^0.6.0",
     "env-var": "^7.4.0",
     "n3": "^1.16.2",


### PR DESCRIPTION
I suspect that the combination of `submissions-dispatcher` and `vendordata-distributions-service` is concurrently manipulating resources in the database, effectively creating a race condition. To tackle this, I propose implementing a throttling mechanism by adding a mutex lock and a random delay.

This change aims to:

- Prevent simultaneous updates to the same resources.
- Reduce the likelihood of race conditions.
- Improve overall system stability.

Let's see
