### PR TITLE
Feature/use exclude properties to fully maintain target

### DIFF
--- a/util/data-manager.js
+++ b/util/data-manager.js
@@ -347,7 +347,7 @@ export async function transferDataToTargets(
     const targetData = await sts.getDataForSubject(
       subject,
       graph,
-      undefined,
+      excludeProperties,
       mode,
     );
     targetStore.addQuads([...targetData]);

--- a/util/data-manager.js
+++ b/util/data-manager.js
@@ -347,7 +347,7 @@ export async function transferDataToTargets(
     const targetData = await sts.getDataForSubject(
       subject,
       graph,
-      excludeProperties,
+      excludeProperties, // So we don't actually clean too much
       mode,
     );
     targetStore.addQuads([...targetData]);


### PR DESCRIPTION
This might break something. Basically, we're facing a situation where source graph -> target = (mirror + user enrichment). I want VDDS to stay away from the enrichment. But in the previous implementation it didn't, probably because that was not the intention. I am wondering whether this would be the silver bullet :grimacing: 