### PR TITLE
Improve performance on large datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,10 +182,10 @@ their respective values. Inserts and deletes are automatically scoped to the
 target graphs, so no need to include a `GRAPH ... { ... }` expression.
 
 **NOTE on the use of prefixes:** any SPARQL pattern or full SPARQL query (like
-`vdds:trigger`, `vdds:targetGraphQuery`, ...) can use the prefixes defined
-globally at the top of the configuration. This service will automatically scan
-every SPARQL pattern for the use of prefixes and include the definition at the
-top of the query. If a SPARQL query already has its own prefixes, they won't be
+`vdds:trigger`, `vdds:graphQuery`, ...) can use the prefixes defined globally
+at the top of the configuration. This service will automatically scan every
+SPARQL pattern for the use of prefixes and include the definition at the top of
+the query. If a SPARQL query already has its own prefixes, they won't be
 included again, so you can shadow the globally defined prefixes per query. This
 mechanism is optimistic: it will not throw errors if prefixes are missing, and
 it might add too many prefixes (which shouldn't cause any harm), because it
@@ -217,8 +217,8 @@ optionality and default values:
 | `vdds:excludeProperty`     | 0 - n       | URIs of the properties that must not be copied to the target graphs. This "blacklists" certain properties, on top of the `vdds:property` properties list. |
 | `vdds:optionalProperty`    | 0 - n       | URIs of optional properties that may be copied to the target graphs. |
 | `vdds:trigger`             | 0 - 1       | SPARQL pattern that will be placed directly in an `ASK` query. Can be used to filter subjects. This could be anything: filter on a certain predicate, if a certain other part of the hierarchy exists or has a certain property, ... Pattern `${subject}` is substituted by the URI of the subject under consideration at the moment. |
-| `vdds:targetGraphQuery`    | 0 - 1       | A full SPARQL `SELECT` query that allows to retrieve variables for constructing the (multiple) target graphs. Can be optional if the target graph is static. The pattern `${subject}` is substituted for the URI of the subject. |
-| `vdds:targetGraphTemplate` | 1           | Template string for the target graph URIs. Variables inside `${}` will be substituted by their respective values from the same variables in the `vdds:targetGraphQuery`. E.g. a string `http://target/graph/${var}` with target graph query like `SELECT ?var WHERE {...}`. |
+| `vdds:graphQuery`          | 0 - 1       | A full SPARQL `SELECT` query that allows to retrieve variables for constructing the (multiple) target graphs. Can be optional if the target graph is static. The pattern `${subject}` is substituted for the URI of the subject. |
+| `vdds:targetGraphTemplate` | 1           | Template string for the target graph URIs. Variables inside `${}` will be substituted by their respective values from the same variables in the `vdds:graphQuery`. E.g. a string `http://target/graph/${var}` with target graph query like `SELECT ?var WHERE {...}`. |
 | `vdds:postProcessDelete`   | 0 - 1       | Provide a SPARQL pattern that will be put in a `DELETE { ... }` expression. If no `INSERT` and `WHERE` patterns are given, this will cause the execution of a `DELETE DATA { ... }` query.
 | `vdds:postProcessInsert`   | 0 - 1       | Idem as for `vdds:postProcessDelete`, but for an `INSERT` expression. |
 | `vdds:postProcessWhere`    | 0 - 1       | Provide a `WHERE { ... }` SPARQL pattern. |

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # vendor-data-distribution-service
 
-Service that copies hierarchical data to target graphs, based on configuration
-that filters subjects on type and an optional trigger query (SPARQL `ASK`
-query). Target graphs are fixed or calculated based on a general SPARQL
-`SELECT` query. For each subject, you can specify which properties to copy by
-whitelists, blacklists, or by marking properties as optional
+<strong>Service that copies hierarchical data from source graphs to target
+graphs, based on configuration that filters subjects on type and an optional
+trigger query (SPARQL `ASK` query). Source and target graphs are fixed or
+calculated based on a general SPARQL `SELECT` query. For each subject, you can
+specify which properties to copy by whitelists, blacklists, or by marking
+properties as optional.</strong>
 
 This service works by listening to delta messages from the `delta-notifier` and
 by copying configurable "pieces of information" (e.g. all data about entities,
@@ -179,7 +180,9 @@ pattern. Idem for a `DELETE` pattern. If you supply both an `INSERT` and
 `DELETE` pattern, you also need to provide a `WHERE` pattern. The patterns
 `${subject}` and `${targetgraph}` in the supplied strings are substituted with
 their respective values. Inserts and deletes are automatically scoped to the
-target graphs, so no need to include a `GRAPH ... { ... }` expression.
+target graphs, so no need to include a `GRAPH ... { ... }` expression. In the
+`WHERE` clause, the variable `?sourceGraph` is bound to the source graphs, it
+they are given in the related configuration.
 
 **NOTE on the use of prefixes:** any SPARQL pattern or full SPARQL query (like
 `vdds:trigger`, `vdds:graphQuery`, ...) can use the prefixes defined globally
@@ -218,7 +221,8 @@ optionality and default values:
 | `vdds:optionalProperty`    | 0 - n       | URIs of optional properties that may be copied to the target graphs. |
 | `vdds:trigger`             | 0 - 1       | SPARQL pattern that will be placed directly in an `ASK` query. Can be used to filter subjects. This could be anything: filter on a certain predicate, if a certain other part of the hierarchy exists or has a certain property, ... Pattern `${subject}` is substituted by the URI of the subject under consideration at the moment. |
 | `vdds:graphQuery`          | 0 - 1       | A full SPARQL `SELECT` query that allows to retrieve variables for constructing the (multiple) target graphs. Can be optional if the target graph is static. The pattern `${subject}` is substituted for the URI of the subject. |
-| `vdds:targetGraphTemplate` | 1           | Template string for the target graph URIs. Variables inside `${}` will be substituted by their respective values from the same variables in the `vdds:graphQuery`. E.g. a string `http://target/graph/${var}` with target graph query like `SELECT ?var WHERE {...}`. |
+| `vdds:targetGraphTemplate` | 1 - n       | Template string for the target graph URIs. Not optional. Variables inside `${}` will be substituted by their respective values from the same variables in the `vdds:graphQuery`. E.g. a string `http://target/graph/${var}` with target graph query like `SELECT ?var WHERE {...}`. |
+| `vdds:sourceGraphTemplate` | 0 - n       | Template string for the source graph URIs. Optional. When not supplied, data from the whole triplestore is used for copying to the target graphs. When given, only data from these source graphs is copied to the target graphs. Variables inside `${}` will be substituted by their respective values from the same variables in the `vdds:graphQuery`. E.g. a string `http://target/graph/${var}` with target graph query like `SELECT ?var WHERE {...}`. |
 | `vdds:postProcessDelete`   | 0 - 1       | Provide a SPARQL pattern that will be put in a `DELETE { ... }` expression. If no `INSERT` and `WHERE` patterns are given, this will cause the execution of a `DELETE DATA { ... }` query.
 | `vdds:postProcessInsert`   | 0 - 1       | Idem as for `vdds:postProcessDelete`, but for an `INSERT` expression. |
 | `vdds:postProcessWhere`    | 0 - 1       | Provide a `WHERE { ... }` SPARQL pattern. |

--- a/README.md
+++ b/README.md
@@ -347,6 +347,9 @@ service. Supply a value for them using the `environment` keyword in the
   the same subjects.
 * `PROCESSING_INTERVAL_SIZE`: <em>(optional, default: 100)</em> amount of
   subject-identifier combinations that will be batch processed at a time.
+* `BATCH_SIZE`: <em>(optional, default: 100)</em> maximum amount of triples to
+  include in DELETE and INSERT queries. Also used as limit for the selection of
+  subjects while healing.
 * `CLEANUP_CRON`: <em>(optional, default: "30 * * * *")</em> periodic cleanup
   job timer. This performs a batch processing of subjects from the temporary
   graph. Can be kept to a minimum, because there should normally be no

--- a/config/model.ttl
+++ b/config/model.ttl
@@ -56,7 +56,7 @@ meb:Submission
     ${subject} a meb:Submission .
   """ ;
   #optional:
-  vdds:targetGraphQuery """
+  vdds:graphQuery """
     SELECT DISTINCT ?organisationUuid ?vendorUuid
     WHERE {
       GRAPH ?g {

--- a/pipeline/deltaProcessing.js
+++ b/pipeline/deltaProcessing.js
@@ -75,11 +75,10 @@ export async function processEventSubjects(subjects) {
   // Target graph for each hierarchy and move parent and children to target
   for (const hierarchy of triggerHappyHierarchies) {
     const { topSubject, topConfig } = hierarchy;
-    const sourceAndTargetGraphs = await dm.sourceAndTargetGraphs(
+    const { sourceGraphs, targetGraphs } = await dm.sourceAndTargetGraphs(
       topSubject,
       topConfig,
     );
-    const { sourceGraphs, targetGraphs } = sourceAndTargetGraphs;
 
     if (!targetGraphs.length) {
       console.log(

--- a/pipeline/deltaProcessing.js
+++ b/pipeline/deltaProcessing.js
@@ -75,7 +75,11 @@ export async function processEventSubjects(subjects) {
   // Target graph for each hierarchy and move parent and children to target
   for (const hierarchy of triggerHappyHierarchies) {
     const { topSubject, topConfig } = hierarchy;
-    const targetGraphs = await dm.targetGraphs(topSubject, topConfig);
+    const sourceAndTargetGraphs = await dm.sourceAndTargetGraphs(
+      topSubject,
+      topConfig,
+    );
+    const { sourceGraphs, targetGraphs } = sourceAndTargetGraphs;
 
     if (!targetGraphs.length) {
       console.log(
@@ -88,15 +92,25 @@ export async function processEventSubjects(subjects) {
     hierarchy.children = await dm.hierarchyChildren(hierarchy);
 
     // Copy entire hierarchy to the target graphs
-    await dm.transferDataToTargets(topSubject, topConfig, targetGraphs);
+    await dm.transferDataToTargets(
+      topSubject,
+      topConfig,
+      targetGraphs,
+      sourceGraphs,
+    );
     for (const { subject, config } of hierarchy.children)
-      await dm.transferDataToTargets(subject, config, targetGraphs);
+      await dm.transferDataToTargets(
+        subject,
+        config,
+        targetGraphs,
+        sourceGraphs,
+      );
 
     // Perform post processing
     for (const graph of targetGraphs) {
-      await dm.postProcess(topSubject, topConfig, graph);
+      await dm.postProcess(topSubject, topConfig, graph, sourceGraphs);
       for (const { subject, config } of hierarchy.children)
-        await dm.postProcess(subject, config, graph);
+        await dm.postProcess(subject, config, graph, sourceGraphs);
     }
   }
   return new ProcessResult(true, triggerHappyHierarchies.length);

--- a/pipeline/healing.js
+++ b/pipeline/healing.js
@@ -110,11 +110,13 @@ export async function healConfigs(configs = []) {
       // Target graph for each hierarchy and move parent and children to target
       for (const hierarchy of triggerHappyHierarchies) {
         const { topSubject, topConfig } = hierarchy;
-        const targetGraphs = await dm.targetGraphs(
+        const sourceAndTargetGraphs = await dm.sourceAndTargetGraphs(
           topSubject,
           topConfig,
           'healing',
         );
+
+        const { sourceGraphs, targetGraphs } = sourceAndTargetGraphs;
 
         if (!targetGraphs.length) {
           console.log(
@@ -131,6 +133,7 @@ export async function healConfigs(configs = []) {
           topSubject,
           topConfig,
           targetGraphs,
+          sourceGraphs,
           'healing',
         );
         for (const { subject, config } of hierarchy.children)
@@ -138,14 +141,27 @@ export async function healConfigs(configs = []) {
             subject,
             config,
             targetGraphs,
+            sourceGraphs,
             'healing',
           );
 
         // Perform post processing
         for (const graph of targetGraphs) {
-          await dm.postProcess(topSubject, topConfig, graph, 'healing');
+          await dm.postProcess(
+            topSubject,
+            topConfig,
+            graph,
+            sourceGraphs,
+            'healing',
+          );
           for (const { subject, config } of hierarchy.children)
-            await dm.postProcess(subject, config, graph, 'healing');
+            await dm.postProcess(
+              subject,
+              config,
+              graph,
+              sourceGraphs,
+              'healing',
+            );
         }
       }
     }

--- a/util/config-manager.js
+++ b/util/config-manager.js
@@ -438,12 +438,12 @@ export function graphQuery(config) {
   return CONFIG.getObjects(config, ns.vdds`graphQuery`)[0];
 }
 
-export function sourceGraphTemplate(config) {
-  return CONFIG.getObjects(config, ns.vdds`sourceGraphTemplate`)[0];
+export function sourceGraphTemplates(config) {
+  return CONFIG.getObjects(config, ns.vdds`sourceGraphTemplate`);
 }
 
-export function targetGraphTemplate(config) {
-  return CONFIG.getObjects(config, ns.vdds`targetGraphTemplate`)[0];
+export function targetGraphTemplates(config) {
+  return CONFIG.getObjects(config, ns.vdds`targetGraphTemplate`);
 }
 
 export function properties(config) {

--- a/util/config-manager.js
+++ b/util/config-manager.js
@@ -149,13 +149,22 @@ function errorOnInvalidConfig() {
   [...classes]
     .filter((subject) => !CONFIG.has(subject, ns.vdds`graphQuery`))
     .forEach((subject) => {
-      const templateStr = CONFIG.getObjects(
+      const targetTemplateStr = CONFIG.getObjects(
         subject,
         ns.vdds`targetGraphTemplate`,
       )[0]?.value;
-      if (templateStr && templateStr.match(/\${\w+}/)?.length > 0) {
+      if (targetTemplateStr && targetTemplateStr.match(/\${\w+}/)?.length > 0) {
         throw new Error(
           `Subject ${rst.termToString(subject)} has no ${rst.termToString(ns.vdds`graphQuery`)}, but uses variables in its ${rst.termToString(ns.vdds`targetGraphTemplate`)}.`,
+        );
+      }
+      const sourceTemplateStr = CONFIG.getObjects(
+        subject,
+        ns.vdds`sourceGraphTemplate`,
+      )[0]?.value;
+      if (sourceTemplateStr && sourceTemplateStr.match(/\${\w+}/)?.length > 0) {
+        throw new Error(
+          `Subject ${rst.termToString(subject)} has no ${rst.termToString(ns.vdds`graphQuery`)}, but uses variables in its ${rst.termToString(ns.vdds`sourceGraphTemplate`)}.`,
         );
       }
     });
@@ -427,6 +436,10 @@ export function trigger(config) {
 
 export function graphQuery(config) {
   return CONFIG.getObjects(config, ns.vdds`graphQuery`)[0];
+}
+
+export function sourceGraphTemplate(config) {
+  return CONFIG.getObjects(config, ns.vdds`sourceGraphTemplate`)[0];
 }
 
 export function targetGraphTemplate(config) {

--- a/util/config-manager.js
+++ b/util/config-manager.js
@@ -144,10 +144,10 @@ function errorOnInvalidConfig() {
       );
   });
 
-  // vdds:Class without vdds:targetGraphQuery and the vdds:targetGraphTemplate
+  // vdds:Class without vdds:graphQuery and the vdds:targetGraphTemplate
   // uses variables
   [...classes]
-    .filter((subject) => !CONFIG.has(subject, ns.vdds`targetGraphQuery`))
+    .filter((subject) => !CONFIG.has(subject, ns.vdds`graphQuery`))
     .forEach((subject) => {
       const templateStr = CONFIG.getObjects(
         subject,
@@ -155,12 +155,12 @@ function errorOnInvalidConfig() {
       )[0]?.value;
       if (templateStr && templateStr.match(/\${\w+}/)?.length > 0) {
         throw new Error(
-          `Subject ${rst.termToString(subject)} has no ${rst.termToString(ns.vdds`targetGraphQuery`)}, but uses variables in its ${rst.termToString(ns.vdds`targetGraphTemplate`)}.`,
+          `Subject ${rst.termToString(subject)} has no ${rst.termToString(ns.vdds`graphQuery`)}, but uses variables in its ${rst.termToString(ns.vdds`targetGraphTemplate`)}.`,
         );
       }
     });
 
-  // vdds:Subclass cannot have vdds:trigger, vdds:targetGraphQuery nor
+  // vdds:Subclass cannot have vdds:trigger, vdds:graphQuery nor
   // vdds:targetGraphTemplate
   [...subclasses].forEach((subject) => {
     if (CONFIG.has(subject, ns.vdds`trigger`)) {
@@ -170,9 +170,9 @@ function errorOnInvalidConfig() {
     }
   });
   [...subclasses].forEach((subject) => {
-    if (CONFIG.has(subject, ns.vdds`targetGraphQuery`))
+    if (CONFIG.has(subject, ns.vdds`graphQuery`))
       throw new Error(
-        `Subclass definition ${rst.termToString(subject)} has a ${rst.termToString(ns.vdds`targetGraphQuery`)}, but this is never used and should be removed for clarity. Only top-level classes can have these queries, not subclasses.`,
+        `Subclass definition ${rst.termToString(subject)} has a ${rst.termToString(ns.vdds`graphQuery`)}, but this is never used and should be removed for clarity. Only top-level classes can have these queries, not subclasses.`,
       );
   });
   [...subclasses].forEach((subject) => {
@@ -425,8 +425,8 @@ export function trigger(config) {
   return CONFIG.getObjects(config, ns.vdds`trigger`)[0];
 }
 
-export function targetGraphQuery(config) {
-  return CONFIG.getObjects(config, ns.vdds`targetGraphQuery`)[0];
+export function graphQuery(config) {
+  return CONFIG.getObjects(config, ns.vdds`graphQuery`)[0];
 }
 
 export function targetGraphTemplate(config) {

--- a/util/data-manager.js
+++ b/util/data-manager.js
@@ -264,10 +264,18 @@ export async function hierarchyChildren(hierarchy, mode) {
   return collectedChildren;
 }
 
+export class SourceAndTargetGraphs {
+  constructor(sourceGraphs, targetGraphs) {
+    this.sourceGraphs = sourceGraphs;
+    this.targetGraphs = targetGraphs;
+  }
+}
+
 /**
  * For a subject and a configuration, execute the graphQuery and substitute the
- * recieved variables with their values in the targetGraphTemplate. This
- * results in possibly multiple target graphs, which are all returned.
+ * recieved variables with their values in the targetGraphTemplate and the
+ * sourceGraphTemplate. This results in possibly multiple target and source
+ * graphs, which are all returned.
  *
  * @public
  * @async
@@ -278,32 +286,54 @@ export async function hierarchyChildren(hierarchy, mode) {
  * subject.
  * @param {String} mode - Optional. Used to differentiate between normal
  * operations ('copy') and healing operations ('healing').
- * @returns {Array(NamedNode)} A collection with NamedNodes representing the
- * calculated target graphs.
+ * @returns {SourceAndTargetGraphs} An instance of SourceAndTargetGraphs with
+ * properties `sourceGraphs` and `targetGraphs` with collections of NamedNodes
+ * representing the calculated source and target graphs respectively.
  */
-export async function targetGraphs(subject, config, mode) {
+export async function sourceAndTargetGraphs(subject, config, mode) {
   const targetQuery = cm.graphQuery(config);
   if (targetQuery) {
     const substitutedQuery = targetQuery.value.replaceAll(
       '${subject}',
       rst.termToString(subject),
     );
-    const targetGraphTemplateStr = cm.targetGraphTemplate(config).value;
     const response = await ss.querySudo(substitutedQuery, mode);
     const vars = response.head.vars;
     const parsedResults = sparqlJsonParser.parseJsonResults(response);
-    return parsedResults.map((res) => {
-      let graph = targetGraphTemplateStr;
+    let targetGraphs,
+      sourceGraphs = [];
+
+    const targetGraphTemplateStr = cm.targetGraphTemplate(config).value;
+    targetGraphs = parsedResults.map((res) => {
+      let targetGraph = targetGraphTemplateStr;
       vars.forEach((varname) => {
         const regex = new RegExp('\\${' + varname + '}', 'g');
-        graph = graph.replaceAll(regex, res[varname].value);
+        targetGraph = targetGraph.replaceAll(regex, res[varname].value);
       });
-      return namedNode(graph);
+      return namedNode(targetGraph);
     });
+
+    const sourceGraphTemplateStr = cm.sourceGraphTemplate(config)?.value;
+    if (sourceGraphTemplateStr) {
+      sourceGraphs = parsedResults.map((res) => {
+        let sourceGraph = sourceGraphTemplateStr;
+        vars.forEach((varname) => {
+          const regex = new RegExp('\\${' + varname + '}', 'g');
+          sourceGraph = sourceGraph.replaceAll(regex, res[varname].value);
+        });
+        return namedNode(sourceGraph);
+      });
+    }
+
+    return new SourceAndTargetGraphs(sourceGraphs, targetGraphs);
   } else {
-    const template = cm.targetGraphTemplate(config);
-    if (template) return [template];
-    else return [];
+    let targetGraphs = [],
+      sourceGraphs = [];
+    const targetGraphTemplate = cm.targetGraphTemplate(config);
+    if (targetGraphTemplate) targetGraphs = [targetGraphTemplate];
+    const sourceGraphTemplate = cm.sourceGraphTemplate(config);
+    if (sourceGraphTemplate) sourceGraphs = [sourceGraphTemplate];
+    return new SourceAndTargetGraphs(sourceGraphs, targetGraphs);
   }
 }
 
@@ -321,6 +351,10 @@ export async function targetGraphs(subject, config, mode) {
  * subject.
  * @param {Array(Literal)} targetGraphs - List of graphs to which to copy data
  * about this subject to, the target graphs.
+ * @param {Array(Literal)} sourceGraphs - List of graphs from which to copy
+ * data about this subject, the source graphs. This can be left undefined or
+ * [undefined] to allow copying from all graphs in the triplestore, basically
+ * from the whole triplestore without graph restrictions.
  * @param {String} mode - Optional. Used to differentiate between normal
  * operations ('copy') and healing operations ('healing').
  * @returns {undefined} Nothing.
@@ -329,8 +363,12 @@ export async function transferDataToTargets(
   subject,
   config,
   targetGraphs,
+  sourceGraphs,
   mode,
 ) {
+  // Hack: if no sourceGraphs, then use `undefined` as a fallback to allow
+  // fetching from all graphs.
+  if (sourceGraphs?.length < 1) sourceGraphs = [undefined];
   const properties = cm.properties(config);
   const optionalProperties = cm.optionalProperties(config);
   const excludeProperties = cm.excludeProperties(config);
@@ -341,42 +379,45 @@ export async function transferDataToTargets(
   // NOTE: do not alter the store after its initial creation!
   const sourceStore = new N3.Store([], { entityIndex });
 
-  // Fetch data that is not in the target graph
-  if (properties === undefined) {
-    // All properties
-    const sourceData = await sts.getDataForSubject(
-      subject,
-      undefined,
-      excludeProperties,
-      mode,
-    );
-    sourceStore.addQuads([...sourceData]);
-  } else {
-    // Specific mandatory properties
-    if (properties?.length > 0) {
-      const leftOverProperties = properties.filter((prop) => {
-        return !excludeProperties.some((ex) => ex.value === prop.value);
-      });
-      const sourceData = await sts.getDataForSubjectMandatoryProperties(
+  // Fetch data that about subjects from all graphs, or the source graphs if
+  // they are given
+  for (const sourceGraph of sourceGraphs) {
+    if (properties === undefined) {
+      // All properties
+      const sourceData = await sts.getDataForSubject(
         subject,
-        undefined,
-        leftOverProperties,
+        sourceGraph,
+        excludeProperties,
         mode,
       );
       sourceStore.addQuads([...sourceData]);
-    }
-    // Specific optional properties
-    if (optionalProperties.length > 0) {
-      const leftOverProperties = optionalProperties.filter((prop) => {
-        return !excludeProperties.some((ex) => ex.value === prop.value);
-      });
-      const sourceData = await sts.getDataForSubjectOptionalProperties(
-        subject,
-        undefined,
-        leftOverProperties,
-        mode,
-      );
-      sourceStore.addQuads([...sourceData]);
+    } else {
+      // Specific mandatory properties
+      if (properties?.length > 0) {
+        const leftOverProperties = properties.filter((prop) => {
+          return !excludeProperties.some((ex) => ex.value === prop.value);
+        });
+        const sourceData = await sts.getDataForSubjectMandatoryProperties(
+          subject,
+          sourceGraph,
+          leftOverProperties,
+          mode,
+        );
+        sourceStore.addQuads([...sourceData]);
+      }
+      // Specific optional properties
+      if (optionalProperties.length > 0) {
+        const leftOverProperties = optionalProperties.filter((prop) => {
+          return !excludeProperties.some((ex) => ex.value === prop.value);
+        });
+        const sourceData = await sts.getDataForSubjectOptionalProperties(
+          subject,
+          sourceGraph,
+          leftOverProperties,
+          mode,
+        );
+        sourceStore.addQuads([...sourceData]);
+      }
     }
   }
   // Remove data from the temp graph.
@@ -384,7 +425,7 @@ export async function transferDataToTargets(
     .getQuads(undefined, undefined, undefined, namedNode(env.TEMP_GRAPH))
     .forEach((quad) => sourceStore.removeQuad(quad));
 
-  for (const graph of targetGraphs) {
+  for (const targetGraph of targetGraphs) {
     const targetStore = new N3.Store([], { entityIndex });
     const sourceStoreCopy = new N3.Store([], { entityIndex });
     // Make a copy of the sourceStore, because we don't want to change the
@@ -397,7 +438,7 @@ export async function transferDataToTargets(
     // data.
     const targetData = await sts.getDataForSubject(
       subject,
-      graph,
+      targetGraph,
       undefined,
       mode,
     );
@@ -422,8 +463,8 @@ export async function transferDataToTargets(
       targetStoreWithoutGraphs,
     );
 
-    await sts.deleteData(right, graph, mode);
-    await sts.insertData(left, graph, mode);
+    await sts.deleteData(right, targetGraph, mode);
+    await sts.insertData(left, targetGraph, mode);
   }
 }
 
@@ -443,11 +484,14 @@ export async function transferDataToTargets(
  * @param {NamedNode} subject - Subject to perform post processing on.
  * @param {Object} config - Configuration object for that subject.
  * @param {NamedNode} graph - Target graph in which to perform the processing.
+ * @param {Array(NamedNode)} sourceGraphs - Collection of NamedNodes
+ * representing possible source graphs from which to select data. Leave
+ * undefined or [undefined] to allow selecting from the whole triplestore.
  * @param {String} mode - Optional. Used to differentiate between normal
  * operations ('copy') and healing operations ('healing').
  * @returns {undefined} Nothing
  */
-export async function postProcess(subject, config, graph, mode) {
+export async function postProcess(subject, config, graph, sourceGraphs, mode) {
   const [deletePattern, insertPattern, wherePattern] = [
     cm.postProcessDelete(config),
     cm.postProcessInsert(config),
@@ -497,12 +541,28 @@ export async function postProcess(subject, config, graph, mode) {
         }
       }`
       : '';
-    query = `
-      ${deletePart}
-      ${insertPart}
-      WHERE {
-        ${wherePattern}
-      }`;
+
+    // If sourceGraphs have been given, only select from there, otherwise
+    // select from the whole triplestore.
+    if (sourceGraphs?.length > 0 && sourceGraphs[0] !== undefined) {
+      const graphValues = sourceGraphs.map(rst.termToString).join('\n');
+      query = `
+        ${deletePart}
+        ${insertPart}
+        WHERE {
+          VALUES ?g { ${graphValues} }
+          GRAPH ?g {
+            ${wherePattern}
+          }
+        }`;
+    } else {
+      query = `
+        ${deletePart}
+        ${insertPart}
+        WHERE {
+          ${wherePattern}
+        }`;
+    }
   }
 
   return ss.updateSudo(query, mode);

--- a/util/data-manager.js
+++ b/util/data-manager.js
@@ -265,10 +265,9 @@ export async function hierarchyChildren(hierarchy, mode) {
 }
 
 /**
- * For a subject and a configuration, execute the targetGraphQuery and
- * substitute the recieved variables with their values in the
- * targetGraphTemplate. This results in possibly multiple target graphs, which
- * are all returned.
+ * For a subject and a configuration, execute the graphQuery and substitute the
+ * recieved variables with their values in the targetGraphTemplate. This
+ * results in possibly multiple target graphs, which are all returned.
  *
  * @public
  * @async
@@ -283,7 +282,7 @@ export async function hierarchyChildren(hierarchy, mode) {
  * calculated target graphs.
  */
 export async function targetGraphs(subject, config, mode) {
-  const targetQuery = cm.targetGraphQuery(config);
+  const targetQuery = cm.graphQuery(config);
   if (targetQuery) {
     const substitutedQuery = targetQuery.value.replaceAll(
       '${subject}',

--- a/util/data-manager.js
+++ b/util/data-manager.js
@@ -556,8 +556,8 @@ export async function postProcess(subject, config, graph, sourceGraphs, mode) {
         ${deletePart}
         ${insertPart}
         WHERE {
-          VALUES ?g { ${graphValues} }
-          GRAPH ?g {
+          VALUES ?sourceGraph { ${graphValues} }
+          GRAPH ?sourceGraph {
             ${wherePattern}
           }
         }`;

--- a/util/data-manager.js
+++ b/util/data-manager.js
@@ -335,10 +335,62 @@ export async function transferDataToTargets(
   const properties = cm.properties(config);
   const optionalProperties = cm.optionalProperties(config);
   const excludeProperties = cm.excludeProperties(config);
+  const entityIndex = new N3.EntityIndex();
+
+  // Create a source store of all the data about the subject
+  // This is created once here and reused below.
+  // NOTE: do not alter the store after its initial creation!
+  const sourceStore = new N3.Store([], { entityIndex });
+
+  // Fetch data that is not in the target graph
+  if (properties === undefined) {
+    // All properties
+    const sourceData = await sts.getDataForSubject(
+      subject,
+      undefined,
+      excludeProperties,
+      mode,
+    );
+    sourceStore.addQuads([...sourceData]);
+  } else {
+    // Specific mandatory properties
+    if (properties?.length > 0) {
+      const leftOverProperties = properties.filter((prop) => {
+        return !excludeProperties.some((ex) => ex.value === prop.value);
+      });
+      const sourceData = await sts.getDataForSubjectMandatoryProperties(
+        subject,
+        undefined,
+        leftOverProperties,
+        mode,
+      );
+      sourceStore.addQuads([...sourceData]);
+    }
+    // Specific optional properties
+    if (optionalProperties.length > 0) {
+      const leftOverProperties = optionalProperties.filter((prop) => {
+        return !excludeProperties.some((ex) => ex.value === prop.value);
+      });
+      const sourceData = await sts.getDataForSubjectOptionalProperties(
+        subject,
+        undefined,
+        leftOverProperties,
+        mode,
+      );
+      sourceStore.addQuads([...sourceData]);
+    }
+  }
+  // Remove data from the temp graph.
+  sourceStore
+    .getQuads(undefined, undefined, undefined, namedNode(env.TEMP_GRAPH))
+    .forEach((quad) => sourceStore.removeQuad(quad));
 
   for (const graph of targetGraphs) {
-    const targetStore = new N3.Store();
-    const sourceStore = new N3.Store();
+    const targetStore = new N3.Store([], { entityIndex });
+    const sourceStoreCopy = new N3.Store([], { entityIndex });
+    // Make a copy of the sourceStore, because we don't want to change the
+    // original store as it is reused.
+    sourceStore.forEach((q) => sourceStoreCopy.addQuad(q));
 
     // Get everything from the target graph, don't filter on mandatory and
     // optional properties, because we know that that data has already gone
@@ -352,62 +404,19 @@ export async function transferDataToTargets(
     );
     targetStore.addQuads([...targetData]);
 
-    // Fetch data that is not in the target graph
-    if (properties === undefined) {
-      // All properties
-      const targetData = await sts.getDataForSubject(
-        subject,
-        undefined,
-        excludeProperties,
-        mode,
-      );
-      sourceStore.addQuads([...targetData]);
-    } else {
-      // Specific mandatory properties
-      if (properties?.length > 0) {
-        const leftOverProperties = properties.filter((prop) => {
-          return !excludeProperties.some((ex) => ex.value === prop.value);
-        });
-        const targetData = await sts.getDataForSubjectMandatoryProperties(
-          subject,
-          undefined,
-          leftOverProperties,
-          mode,
-        );
-        sourceStore.addQuads([...targetData]);
-      }
-      // Specific optional properties
-      if (optionalProperties.length > 0) {
-        const leftOverProperties = optionalProperties.filter((prop) => {
-          return !excludeProperties.some((ex) => ex.value === prop.value);
-        });
-        const targetData = await sts.getDataForSubjectOptionalProperties(
-          subject,
-          undefined,
-          leftOverProperties,
-          mode,
-        );
-        sourceStore.addQuads([...targetData]);
-      }
-    }
-    // Specifically remove all the quads from all the target graphs and the temp graph
+    // Specifically remove all the quads from all the target graphs.
     for (const possibleTargetGraph of targetGraphs) {
-      sourceStore
+      sourceStoreCopy
         .getQuads(undefined, undefined, undefined, possibleTargetGraph)
-        .forEach((quad) => sourceStore.removeQuad(quad));
+        .forEach((quad) => sourceStoreCopy.removeQuad(quad));
     }
-    sourceStore
-      .getQuads(undefined, undefined, undefined, namedNode(env.TEMP_GRAPH))
-      .forEach((quad) => sourceStore.removeQuad(quad));
 
-    const sourceStoreWithoutGraphs = new N3.Store();
-    sourceStore.forEach((q) =>
-      sourceStoreWithoutGraphs.addQuad(q.subject, q.predicate, q.object),
-    );
-    const targetStoreWithoutGraphs = new N3.Store();
-    targetStore.forEach((q) =>
-      targetStoreWithoutGraphs.addQuad(q.subject, q.predicate, q.object),
-    );
+    const sourceStoreWithoutGraphs = new N3.Store([], { entityIndex });
+    for (const q of sourceStoreCopy)
+      sourceStoreWithoutGraphs.addQuad(q.subject, q.predicate, q.object);
+    const targetStoreWithoutGraphs = new N3.Store([], { entityIndex });
+    for (const q of targetStore)
+      targetStoreWithoutGraphs.addQuad(q.subject, q.predicate, q.object);
 
     const { left, right } = hel.compareStores(
       sourceStoreWithoutGraphs,

--- a/util/data-manager.js
+++ b/util/data-manager.js
@@ -300,39 +300,45 @@ export async function sourceAndTargetGraphs(subject, config, mode) {
     const response = await ss.querySudo(substitutedQuery, mode);
     const vars = response.head.vars;
     const parsedResults = sparqlJsonParser.parseJsonResults(response);
-    let targetGraphs,
+    let targetGraphs = [],
       sourceGraphs = [];
 
-    const targetGraphTemplateStr = cm.targetGraphTemplate(config).value;
-    targetGraphs = parsedResults.map((res) => {
-      let targetGraph = targetGraphTemplateStr;
-      vars.forEach((varname) => {
-        const regex = new RegExp('\\${' + varname + '}', 'g');
-        targetGraph = targetGraph.replaceAll(regex, res[varname].value);
-      });
-      return namedNode(targetGraph);
-    });
-
-    const sourceGraphTemplateStr = cm.sourceGraphTemplate(config)?.value;
-    if (sourceGraphTemplateStr) {
-      sourceGraphs = parsedResults.map((res) => {
-        let sourceGraph = sourceGraphTemplateStr;
-        vars.forEach((varname) => {
+    const targetGraphTemplateStrs = cm
+      .targetGraphTemplates(config)
+      .map((tgt) => tgt.value);
+    for (const result of parsedResults) {
+      for (let targetGraphStr of targetGraphTemplateStrs) {
+        for (const varname of vars) {
           const regex = new RegExp('\\${' + varname + '}', 'g');
-          sourceGraph = sourceGraph.replaceAll(regex, res[varname].value);
-        });
-        return namedNode(sourceGraph);
-      });
+          targetGraphStr = targetGraphStr.replaceAll(
+            regex,
+            result[varname].value,
+          );
+        }
+        targetGraphs.push(namedNode(targetGraphStr));
+      }
+    }
+
+    const sourceGraphTemplateStrs = cm
+      .sourceGraphTemplates(config)
+      .map((tgt) => tgt.value);
+    for (const result of parsedResults) {
+      for (let sourceGraphStr of sourceGraphTemplateStrs) {
+        for (const varname of vars) {
+          const regex = new RegExp('\\${' + varname + '}', 'g');
+          sourceGraphStr = sourceGraphStr.replaceAll(
+            regex,
+            result[varname].value,
+          );
+        }
+        sourceGraphs.push(namedNode(sourceGraphStr));
+      }
     }
 
     return new SourceAndTargetGraphs(sourceGraphs, targetGraphs);
   } else {
-    let targetGraphs = [],
-      sourceGraphs = [];
-    const targetGraphTemplate = cm.targetGraphTemplate(config);
-    if (targetGraphTemplate) targetGraphs = [targetGraphTemplate];
-    const sourceGraphTemplate = cm.sourceGraphTemplate(config);
-    if (sourceGraphTemplate) sourceGraphs = [sourceGraphTemplate];
+    const targetGraphs = cm.targetGraphTemplates(config);
+    const sourceGraphs = cm.sourceGraphTemplates(config);
     return new SourceAndTargetGraphs(sourceGraphs, targetGraphs);
   }
 }

--- a/util/storeToTriplestore.js
+++ b/util/storeToTriplestore.js
@@ -323,7 +323,7 @@ export async function insertData(store, graph, mode) {
         await insertTriplesInGraphWithoutBatching(graph, batch, mode);
         start += batchSize;
         batchSize = originalBatchSize;
-      } catch {
+      } catch (err) {
         if (batchSize > 1) {
           batchSize = Math.ceil(batchSize / 2);
         } else {
@@ -332,8 +332,10 @@ export async function insertData(store, graph, mode) {
             rst.termToString(triples[start].predicate),
             rst.termToString(triples[start].object),
           ].join(' ');
+          console.error(err);
           throw new Error(
             `The following triple could not be inserted into the triplestore:\n\t${tripleString}\nThis might be because of a network issue, a syntax issue or because the triple is too long.`,
+            { cause: err },
           );
         }
       }
@@ -411,7 +413,7 @@ export async function deleteData(store, graph, mode) {
         await deleteTriplesFromGraphWithoutBatching(graph, batch, mode);
         start += batchSize;
         batchSize = originalBatchSize;
-      } catch {
+      } catch (err) {
         if (batchSize > 1) {
           batchSize = Math.ceil(batchSize / 2);
         } else {
@@ -420,8 +422,10 @@ export async function deleteData(store, graph, mode) {
             rst.termToString(triples[start].predicate),
             rst.termToString(triples[start].object),
           ].join(' ');
+          console.error(err);
           throw new Error(
             `The following triple could not be removed from the triplestore:\n\t${tripleString}\nThis might be because of a network issue, a syntax issue or because the triple is too long.`,
+            { cause: err },
           );
         }
       }

--- a/util/storeToTriplestore.js
+++ b/util/storeToTriplestore.js
@@ -313,31 +313,77 @@ export async function getDataFromConstructQuery(query, overrideGraph) {
  */
 export async function insertData(store, graph, mode) {
   const insertFunction = async (store, graph) => {
-    const writer = new N3.Writer();
-    store.forEach((q) => writer.addQuad(q.subject, q.predicate, q.object));
-    const triplesSparql = await new Promise((resolve, reject) =>
-      writer.end((error, result) => {
-        if (error) reject(error);
-        else resolve(result);
-      }),
-    );
-    await ss.updateSudo(
-      `INSERT DATA {
-        GRAPH ${rst.termToString(graph)} {
-          ${triplesSparql}
+    const triples = [...store];
+    let batchSize = env.BATCH_SIZE;
+    const originalBatchSize = env.BATCH_SIZE;
+    let start = 0;
+    while (start < triples.length) {
+      try {
+        const batch = triples.slice(start, start + batchSize);
+        await insertTriplesInGraphWithoutBatching(graph, batch, mode);
+        start += batchSize;
+        batchSize = originalBatchSize;
+      } catch {
+        if (batchSize > 1) {
+          batchSize = Math.ceil(batchSize / 2);
+        } else {
+          const tripleString = [
+            rst.termToString(triples[start].subject),
+            rst.termToString(triples[start].predicate),
+            rst.termToString(triples[start].object),
+          ].join(' ');
+          throw new Error(
+            `The following triple could not be inserted into the triplestore:\n\t${tripleString}\nThis might be because of a network issue, a syntax issue or because the triple is too long.`,
+          );
         }
-      }`,
-      mode,
-    );
+      }
+    }
   };
 
   if (store.size < 1) return;
   if (graph) await insertFunction(store, graph);
   else
     for (const graph of store.getGraphs()) {
-      const triples = store.getQuads(undefined, undefined, undefined, graph);
-      await insertFunction(triples, graph);
+      const triplesSet = store.match(undefined, undefined, undefined, graph);
+      await insertFunction(triplesSet, graph);
     }
+}
+
+/**
+ * Inserts an N3 Store into the triplestore.
+ *
+ * @public
+ * @async
+ * @function
+ * @param {NamedNode} graph - Target graph where the triples should be inserted
+ * into.
+ * @param {N3.Store|Iterable} store - Store or other iterable collection
+ * containing the data that needs to be inserted.
+ * @param {String} mode - Optional. Used to differentiate between normal
+ * operations ('copy') and healing operations ('healing').
+ * @returns {undefined} Nothing. (Might return the response object of a REST
+ * call to the triplestore to insert the data.)
+ */
+async function insertTriplesInGraphWithoutBatching(graph, store, mode) {
+  if (store.size && store.size <= 0) return;
+  if (store.length && store.length <= 0) return;
+  //Use a proper writer for when the data is properly formatted.
+  const writer = new N3.Writer();
+  store.forEach((q) => writer.addQuad(q.subject, q.predicate, q.object));
+  const triplesSparql = await new Promise((resolve, reject) =>
+    writer.end((error, result) => {
+      if (error) reject(error);
+      else resolve(result);
+    }),
+  );
+  return await ss.updateSudo(
+    `INSERT DATA {
+      GRAPH ${rst.termToString(graph)} {
+        ${triplesSparql}
+      }
+    }`,
+    mode,
+  );
 }
 
 /**
@@ -386,8 +432,8 @@ export async function deleteData(store, graph, mode) {
   if (graph) await deleteFunction(store, graph);
   else
     for (const graph of store.getGraphs()) {
-      const triples = store.getQuads(undefined, undefined, undefined, graph);
-      await deleteFunction(triples, graph);
+      const triplesSet = store.match(undefined, undefined, undefined, graph);
+      await deleteFunction(triplesSet, graph);
     }
 }
 
@@ -440,7 +486,7 @@ async function deleteTriplesFromGraphWithoutBatching(graph, store, mode) {
       triplesSparql.push(formatTriple(quad));
   });
   if (triplesSparql.length)
-    await ss.updateSudo(
+    return await ss.updateSudo(
       `DELETE DATA {
         GRAPH ${rst.termToString(graph)} {
           ${triplesSparql.join('\n')}


### PR DESCRIPTION
**[DL-7378]**

In some datasets, URIs are reused between organisations, but every organisation might have different values for those subjects. E.g. a logical file that has a different creation date in every organisation.

This PR implements "source graphs", an optional configuration entry that limits the select while copying data to target graphs. Source graphs and target graphs have also been made plural, allowing multiple source graphs and multiple target graphs.

Some further optimisations:

* Source data is only queried once per subject, and an in-memory copy is used for the rest of the transfers (but entity indexes are shared between the stores to limit memory usage).
* Inserts are now batched like deletes already where.